### PR TITLE
Fix analysis overflow on smaller viewport widths

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -30,16 +30,17 @@ a:hover {
 }
 
 #container {
-  padding: 5px;
+  padding: 0px;
   padding-top: 20px;
   margin: 0 auto;
   display: grid;
   grid-template-rows: auto 1fr auto;
-  height: 97vh;
-  width: 95vw;
+  height: 100vh;
+  width: 100vw;
 }
 
 header {
+  width: 100vw;
   display: flex;
   align-items: center;
   background: inherit;
@@ -136,7 +137,8 @@ input[type="file"]::file-selector-button {
 }
 
 .about--main {
-  margin-left: 20px;
+  margin-left: 5vw;
+  width: 90w;
   background-color: #ffffff;
   border-radius: 25px;
   padding-left: 25px;
@@ -189,9 +191,8 @@ form input[type="submit"]:hover {
 footer {
   display: flex;
   font-size: 15px;
-  margin-top: 30px;
-  margin-left: 15px;
-  width: 100%;
+  padding: 30px 15px;
+  width: 100vw;
 }
 
 .social {
@@ -299,6 +300,12 @@ footer {
   color: #333;
 }
 
+.sum-link,
+.pdf-link,
+.url-link {
+  overflow-wrap: break-word;
+}
+
 .pdf-link,
 .url-link {
   text-decoration: none;
@@ -367,12 +374,15 @@ footer {
     padding-top: 10px;
   }
 
+  .home--main {
+    padding-top: 100px;
+  }
+
   .main--content {
     margin-bottom: 0px;
   }
 
   form {
-    margin-left: 5%;
     background-color: #ffffff;
     padding: 25px;
   }
@@ -403,6 +413,8 @@ footer {
     display: flex;
     align-items: center;
     position: fixed;
+    left: 0px;
+    top: 0px;
     background-color: #ffffff;
     align-items: center;
     z-index: 1;
@@ -447,11 +459,22 @@ footer {
   .about--main .important {
     margin-top: 80px;
     font-size: 38px;
+    text-align: center;
+  }
+
+  .download-pdf,
+  .download-report {
+    text-align: center;
   }
 
   .about--main {
-    width: 90%;
-    margin-left: 10px;
+    width: 90vw;
+    margin-left: 5vw;
+    margin-top: calc(100px + 5vw);
+  }
+
+  #summary ol {
+    padding-left: 20px;
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #6 

It doesn't look like there is recent activity on this so I thought I'd contribute a fix! I was able to get this running locally without a hitch, so, thanks very much for the improved installation directions! The analysis process does seem slow, but I'm experiencing the same on the heroku hosted version so I don't think its an issue with my local build.

I fixed the page overflow issue (which was caused mainly by wrapping issues on the long PDF file names, as well as by some odd behavior when CSS widths were set to 100%.) I also fixed a few other minor mobile issues that I came across that were caused by incorrect margin or width settings. I've tested on iOS and on a few devices in an Android emulator to verify the fix.

<img width="399" alt="Screen Shot 2021-12-10 at 1 41 12 PM" src="https://user-images.githubusercontent.com/84106309/145618410-b20397d6-4bf8-4c10-a3db-ffd6ec231493.png">
<img width="657" alt="Screen Shot 2021-12-10 at 1 41 23 PM" src="https://user-images.githubusercontent.com/84106309/145618420-742e573d-f5ae-4f5d-9d41-6c500596c9b0.png">
<img width="655" alt="Screen Shot 2021-12-10 at 1 41 34 PM" src="https://user-images.githubusercontent.com/84106309/145618433-dcaff240-360f-49dc-a036-b7a2c39a6983.png">

<img width="399" alt="Screen Shot 2021-12-10 at 1 38 57 PM" src="https://user-images.githubusercontent.com/84106309/145618449-538ebaac-90fa-420f-9900-f79f42565d3c.png">
<img width="640" alt="Screen Shot 2021-12-10 at 1 39 27 PM" src="https://user-images.githubusercontent.com/84106309/145618478-7ada312a-56d4-403e-8c03-7144f2c43cd9.png">
<img width="985" alt="Screen Shot 2021-12-10 at 1 39 15 PM" src="https://user-images.githubusercontent.com/84106309/145618494-a3ab9551-02d3-4431-b12e-262c02fa2c32.png">

