### PR TITLE
Feat enhance analysis page design

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -505,7 +505,7 @@ footer {
   transition: 0.25s ease-out;
 }
 
-.accordion-collapsed .accordion-chevron {
+.accordion-collapsed .accordion-chevron svg {
   transform: rotate(0deg);
 }
 
@@ -515,8 +515,8 @@ footer {
   overflow: hidden;
 }
 
-.accordion-expanded .accordion-chevron {
-  transform: rotate(-180deg) translateY(25%);
+.accordion-expanded .accordion-chevron svg {
+  transform: rotate(45deg);
 }
 
 .accordion-expanded .accordion-content {
@@ -528,9 +528,12 @@ footer {
   position: absolute;
   right: 0px;
   bottom: 0px;
-  margin: 1rem;
-  transition: transform 0.5s ease-out;
+  margin: 0.8rem;
   cursor: pointer;
+}
+
+.accordion-chevron svg {
+  transition: transform 0.5s ease-out;
 }
 
 @media only screen and (max-width: 680px) {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -505,6 +505,10 @@ footer {
   transition: 0.25s ease-out;
 }
 
+.accordion-collapsed .subhead {
+  border-bottom: none;
+}
+
 .accordion-collapsed .accordion-chevron svg {
   transform: rotate(0deg);
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -164,6 +164,10 @@ input[type="file"]::file-selector-button {
   color: #EF3B24;
 }
 
+.subhead-lockup {
+  position: relative;
+}
+
 .subhead {
   font-size: 2rem;
   font-weight: 600;
@@ -357,6 +361,7 @@ footer {
   column-gap: 10px;
   row-gap: 15px;
   margin: 15px 0px;
+  font-size: 0.9rem;
 }
 
 .meta-values {
@@ -488,6 +493,44 @@ footer {
 .download-pdf a:hover,
 .download-report a:hover {
   color: #fff;
+}
+
+/**
+* 
+* Styles related to accordion content
+*
+*/
+
+.accordion-content {
+  transition: 0.25s ease-out;
+}
+
+.accordion-collapsed .accordion-chevron {
+  transform: rotate(0deg);
+}
+
+.accordion-collapsed .accordion-content {
+  height: 0px;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.accordion-expanded .accordion-chevron {
+  transform: rotate(-180deg) translateY(25%);
+}
+
+.accordion-expanded .accordion-content {
+  height: 100%;
+  opacity: 1;
+}
+
+.accordion-chevron {
+  position: absolute;
+  right: 0px;
+  bottom: 0px;
+  margin: 1rem;
+  transition: transform 0.5s ease-out;
+  cursor: pointer;
 }
 
 @media only screen and (max-width: 680px) {

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -35,6 +35,18 @@
           element.classList.add("mobile-navigation__open");
         }
       }
+      
+      function toggleAccordionContent(e) {
+        const { classList } = e.currentTarget.parentElement;
+        if (classList.contains("accordion-collapsed")) {
+          classList.remove("accordion-collapsed");
+          classList.add("accordion-expanded");
+        }
+        else if (classList.contains("accordion-expanded")) {
+          classList.remove("accordion-expanded");
+          classList.add("accordion-collapsed");
+        }
+      }
     </script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   </head>
@@ -142,9 +154,19 @@
               <i class="fa fa-check-circle text-success"></i>
               {% endif %}
             </div>
-            <div class="fetch-response"><b>{{pdf[0]}}</b></div>
+            <div class="fetch-response">
+              <b>
+                {% if pdf[0] != 200 and pdf[0] != 403 and pdf[0] != 404 %}
+                  N/A
+                {% else %}
+                  {{pdf[0]}}
+                {% endif %}
+              </b>
+            </div>
             <div class="link-container">
-              <a class="pdf-link" target="_blank" href="{{pdf[1]}}">{{pdf[1]}}</a>
+              <a class="pdf-link" target="_blank" href="{{pdf[1]}}">
+                {{pdf[1]}}
+              </a>
             </div>
             </li>
           {% endfor %}
@@ -173,13 +195,29 @@
           </ul>
         </div>
       </div>
-        <div id="doc-info">
-          <h1 class="subhead">Document Information</h1>
-          <div class="meta-grid">
-            {% for i in meta_titles %}{% set item_1 = meta_titles[loop.index-1]
-            %} {% set item_2 = meta_values[loop.index-1] %}
-            <div class="meta-title"><b>{{item_1}}:</b></div>
-            <div class="meta-values">{{item_2}}</div>
+        <div id="doc-info" class="accordion-collapsed">
+          <div class="subhead-lockup accordion-title" onclick="toggleAccordionContent(event)">
+            <h1 class="subhead">Document Information</h1>
+            <div class="accordion-chevron">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
+                <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+              </svg>
+            </div>
+          </div>
+          <div class="meta-grid accordion-content">
+            {% for i in meta_titles %}
+              {% set title = meta_titles[loop.index-1] %}
+              {% set value = meta_values[loop.index-1] %}
+              {% if "Date" in title %}
+                {% set value = '{y}-{mo}-{d} {h}:{m} UTC{th}:{tm}'.format(
+                  d=value[8:10], mo=value[6:8], y=value[2:6], h=value[10:12], m=value[12:14], s=value[14:16], th=value[16:19], tm=value[20:22]) %}
+              {% else %}
+                {% set value = value | replace("{", "") %} 
+                {% set value = value | replace("}", "") %} 
+                {% set value = value | replace("'", "") %} 
+              {% endif %}
+            <div class="meta-title"><b>{{title[0:1]|capitalize}}{{title[1:]}}:</b></div>
+            <div class="meta-values" style="white-space: pre-wrap">{{value | replace(", ", "\n")}}</div>
             {% endfor %}
           </div>
         </div>

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -199,8 +199,8 @@
           <div class="subhead-lockup accordion-title" onclick="toggleAccordionContent(event)">
             <h1 class="subhead">Document Information</h1>
             <div class="accordion-chevron">
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
-                <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+              <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-plus" viewBox="0 0 16 16">
+                <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/>
               </svg>
             </div>
           </div>


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #5 

Makes Document Info section collapsed on page load with the option to expand, per discussion, and improves the formatting of the document info data. Also fixes a minor formatting error with response codes other than 200/403/404.

<img width="1064" alt="Screen Shot 2021-12-16 at 12 05 33 PM" src="https://user-images.githubusercontent.com/84106309/146406567-06048601-6015-4b25-81c0-4128be091c16.png">

<img width="1080" alt="Screen Shot 2021-12-16 at 11 58 53 AM" src="https://user-images.githubusercontent.com/84106309/146405453-5b52a63c-43bb-47e5-a85b-2aeedb969ac1.png">

