### PR TITLE
Fix: Rename alert function

### DIFF
--- a/templates/upload.html
+++ b/templates/upload.html
@@ -47,7 +47,7 @@
     }</script>
     <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js'></script>
   </head>
-  <body onload="showAlerts()">
+  <body onload="showAlert()">
 
     <div class="mobile-navigation" id="mobile-navigation">
       <div class="mobile-navigation--header">


### PR DESCRIPTION
Alerts are not showing on the site because there is a error in the function name. The `onload` function in the body tag invokes `showAlerts()` but the name of the function is `showAlert()`.

https://github.com/marshalmiller/rottingresearch/blob/3111793812116c94a3e80f03909ef48e147780c5/templates/upload.html#L50

https://github.com/marshalmiller/rottingresearch/blob/3111793812116c94a3e80f03909ef48e147780c5/templates/upload.html#L168

![image](https://user-images.githubusercontent.com/17150767/171073606-0b87ead5-b0c7-4cd8-974b-972117edcb7c.png)
