### PR TITLE
Removing Python2 Support for threadpool.py

### DIFF
--- a/threadpool.py
+++ b/threadpool.py
@@ -1,14 +1,14 @@
-"""
+'''
 file: threadpool.py
 description: Inspired by http://stackoverflow.com/a/7257510
-"""
+'''
 
 from queue import Queue
 from threading import Thread
 
 
 class Worker(Thread):
-    """ Thread executing tasks from a given tasks queue """
+    ''' Thread executing tasks from a given tasks queue '''
 
     def __init__(self, tasks):
         Thread.__init__(self)
@@ -28,7 +28,7 @@ class Worker(Thread):
 
 
 class ThreadPool:
-    """ Pool of threads consuming tasks from a queue """
+    ''' Pool of threads consuming tasks from a queue '''
 
     def __init__(self, num_threads):
         self.tasks = Queue(num_threads)
@@ -36,14 +36,14 @@ class ThreadPool:
             Worker(self.tasks)
 
     def add_task(self, func, *args, **kargs):
-        """ Add a task to the queue """
+        ''' Add a task to the queue '''
         self.tasks.put((func, args, kargs))
 
     def map(self, func, args_list):
-        """ Add a list of tasks to the queue """
+        ''' Add a list of tasks to the queue '''
         for args in args_list:
             self.add_task(func, args)
 
     def wait_completion(self):
-        """ Wait for completion of all the tasks in the queue """
+        ''' Wait for completion of all the tasks in the queue '''
         self.tasks.join()

--- a/threadpool.py
+++ b/threadpool.py
@@ -1,18 +1,10 @@
 """
-Inspired by http://stackoverflow.com/a/7257510
+file: threadpool.py
+description: Inspired by http://stackoverflow.com/a/7257510
 """
 
+from queue import Queue
 from threading import Thread
-import sys
-
-IS_PY2 = sys.version_info < (3, 0)
-
-if IS_PY2:
-    # Python 2
-    from Queue import Queue
-else:
-    # Python 3
-    from queue import Queue
 
 
 class Worker(Thread):
@@ -55,21 +47,3 @@ class ThreadPool:
     def wait_completion(self):
         """ Wait for completion of all the tasks in the queue """
         self.tasks.join()
-
-
-if __name__ == "__main__":
-    from random import randrange
-    from time import sleep
-
-    delays = [randrange(5, 10) for i in range(100)]
-
-    def wait_delay(d):
-        print("sleeping for (%d)sec" % d)
-        sleep(d)
-
-    pool = ThreadPool(5)
-
-    for i, d in enumerate(delays):
-        pool.add_task(wait_delay, d)
-
-    pool.wait_completion()


### PR DESCRIPTION
Removing Python 2 support for `threadpool.py` because we are running the application in a docker container there is no need to support Python 2.  Unless we are expecting the application to be run in to be run in a Python 2 environment. [Considering Python 2 is no longer supported](https://www.python.org/doc/sunset-python-2/). I believe we don't need to support Python 2.