### PR TITLE
Fix: Unnecessary scroll on landing page (desktop view) #62

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -12,6 +12,7 @@ body {
   margin-right: 0px;
   color: black;
   background-color: #ef3b24;
+  overflow: hiddne;
 }
 
 .logo {


### PR DESCRIPTION
Issue: Unnecessary scroll on landing page (desktop view) #62 

Change: Add property `overflow: hidden` to the `body` tag in the `static/css/styles.css` to hide content overflow.